### PR TITLE
Fixing test execution when libjna is installed + adding support for Adding support for Access-Control-Request-Headers / Access-Control-Allow-Headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
     </developer>
   </developers>
 
+  <dependencies>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>3.2.2</version>
+    </dependency>
+  </dependencies>
+
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/src/main/resources/org/jenkinsci/plugins/corsfilter/AccessControlsFilter/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/corsfilter/AccessControlsFilter/global.jelly
@@ -10,5 +10,8 @@
     <f:entry title="Access-Control-Allow-Methods" field="allowedMethods">
       <f:textbox/>
     </f:entry>
+    <f:entry title="Access-Control-Allow-Headers" field="allowedHeaders">
+      <f:textbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/corsfilter/AccessControlsFilter/help-allowedHeaders.html
+++ b/src/main/resources/org/jenkinsci/plugins/corsfilter/AccessControlsFilter/help-allowedHeaders.html
@@ -1,0 +1,6 @@
+<div>
+  Specifies the header or headers allowed when accessing the Jenkins resources. This is used in response to a pre-flight
+  request containing Access-Control-Request-Headers
+
+  For example: Content-Type
+</div>

--- a/src/test/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilterTest.java
@@ -62,4 +62,19 @@ public class AccessControlsFilterTest extends JenkinsRule {
         assertEquals(htmlPage.getWebResponse().getResponseHeaderValue("Access-Control-Allow-Origin"), "http://localhost:9000");
     }
 
+    @Test
+    public void testAllowHeaders() throws Exception {
+        descriptor.setAllowedMethods("GET, OPTIONS");
+        descriptor.setAllowedOrigins("http://localhost:9000, http://localhost:8080");
+        descriptor.setAllowedHeaders("Origin, Content-Type, X-Foo");
+        descriptor.setEnabled(true);
+
+        client.addRequestHeader("Origin", "http://localhost:9000");
+        client.addRequestHeader("Access-Control-Request-Headers", "Content-Type");
+        HtmlPage htmlPage = client.goTo("");
+
+        assertTrue(Boolean.valueOf(htmlPage.getWebResponse().getResponseHeaderValue("Access-Control-Allow-Credentials")));
+        assertEquals(htmlPage.getWebResponse().getResponseHeaderValue("Access-Control-Allow-Headers"), "Content-Type");
+    }
+
 }


### PR DESCRIPTION
Fixing test execution when libjna is installed, see https://bugs.launchpad.net/ubuntu/+source/libjna-java/+bug/1065253 for details
