### PR TITLE
[JENKINS-37231] CORS allowed origins list never updated

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilter.java
@@ -184,9 +184,7 @@ public class AccessControlsFilter implements Filter, Describable<AccessControlsF
         }
 
         public Object readResolve() throws ObjectStreamException {
-            if (allowedOriginsList == null) {
-                createAllowedOriginsList(allowedOrigins);
-            }
+            createAllowedOriginsList(allowedOrigins);
             return this;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilter.java
@@ -15,6 +15,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.ObjectStreamException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -180,6 +181,13 @@ public class AccessControlsFilter implements Filter, Describable<AccessControlsF
 
         public List<String> getAllowedOriginsList() {
             return allowedOriginsList;
+        }
+
+        public Object readResolve() throws ObjectStreamException {
+            if (allowedOriginsList == null) {
+                createAllowedOriginsList(allowedOrigins);
+            }
+            return this;
         }
 
         public boolean isEnabled() {

--- a/src/test/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilterTest.java
@@ -48,6 +48,7 @@ public class AccessControlsFilterTest extends JenkinsRule {
         descriptor.setExposedHeaders("X-Requested-With");
         descriptor.setMaxAge("999");
         descriptor.setEnabled(true);
+        descriptor.reloadAllowedOriginsList();
 
         client.addRequestHeader("Origin", "*");
         HtmlPage htmlPage = client.goTo("");
@@ -63,6 +64,7 @@ public class AccessControlsFilterTest extends JenkinsRule {
         descriptor.setExposedHeaders("X-Requested-With");
         descriptor.setMaxAge("999");
         descriptor.setEnabled(true);
+        descriptor.reloadAllowedOriginsList();
 
         client.addRequestHeader("Origin", "http://localhost:9000");
         HtmlPage htmlPage = client.goTo("");


### PR DESCRIPTION
This is only a fix for JENKINS-37231 so I haven't refactor the plugin code. I will do later.

My goals have been reload list only on each configuration change, not always the list is requested.

List moved to DescriptorImpl as transient.
Added reload method (test requires)