### PR TITLE
Allow whitespace around origin list in config page

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/corsfilter/AccessControlsFilter.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.corsfilter;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Injector;
 import hudson.Extension;
 import hudson.init.InitMilestone;
@@ -165,10 +166,12 @@ public class AccessControlsFilter implements Filter, Describable<AccessControlsF
             return super.configure(req, json);
         }
 
-        private List<String> createAllowedOriginsList(String allowedOrigins) {
+        @VisibleForTesting
+        static List<String> createAllowedOriginsList(String allowedOrigins) {
             final List<String> allowedOriginsList;
             if (allowedOrigins != null && !allowedOrigins.trim().isEmpty()) {
-                allowedOriginsList = Arrays.asList(allowedOrigins.split(","));
+                // Split list on commas and remove whitespace
+                allowedOriginsList = Arrays.asList(allowedOrigins.split("\\s*,\\s*"));
             } else {
                 allowedOriginsList = Collections.EMPTY_LIST;
             }

--- a/src/test/java/org/jenkinsci/plugins/corsfilter/AccessControlFilterTestWithoutJenkins.java
+++ b/src/test/java/org/jenkinsci/plugins/corsfilter/AccessControlFilterTestWithoutJenkins.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.corsfilter;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+
+public class AccessControlFilterTestWithoutJenkins {
+
+    @Test
+    public void testCreateAllowedOriginsListRemovesWhitespace() {
+        List<String> list = AccessControlsFilter.DescriptorImpl.createAllowedOriginsList("foo,bar ,    baz      ,      wibble");
+
+        assertThat(list, hasItems("foo", "bar", "baz", "wibble"));
+    }
+
+}


### PR DESCRIPTION
At the moment, if you try to configure the allowed origins section of the plugin with `http://foo, http://bar`, then it will add " http://bar" (note the leading space) to the list of allowed origins. When a request comes in from "http://bar", it will not match (due to the whitespace) so the plugin won't add the CORS header.